### PR TITLE
fix target architecture selection on macos

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -504,6 +504,13 @@ workspace "ImGui"
 
 	if not os.architecture then
 		function os.architecture()
+			if os.target() == "macosx" then
+				local target_arch = os.targetarch()
+				-- targetarch has to be set explicitly, so fall back to host arch if it's not
+				if target_arch == nil then target_arch = os.hostarch() end
+				return target_arch:lower()
+			end
+
 			-- Check for ARM64 first
 			local arch = os.getenv("PROCESSOR_ARCHITECTURE") or ""
 			local archw6432 = os.getenv("PROCESSOR_ARCHITEW6432") or ""


### PR DESCRIPTION
Hey there. When building on MacOS the output filename had wrong architecture, so I had to fix it. I _think_ this targetarch/hostarch check could be done on every OS, but I currently don't have access to a Windows machine to check, so I scoped it to `os.target() == "macosx"`.