### PR TITLE
fix: split Linux/MacOS when clause for libstdc++/libc++ require

### DIFF
--- a/imgui.odin
+++ b/imgui.odin
@@ -1,6 +1,8 @@
 package imgui
 
-when ODIN_OS == .Linux || ODIN_OS == .Darwin {
+when ODIN_OS == .Linux {
+	@(require) foreign import stdcpp "system:stdc++"
+} else when ODIN_OS == .Darwin {
 	@(require) foreign import stdcpp "system:c++"
 }
 


### PR DESCRIPTION
The original code grouped Darwin and Linux together but most Linux distros ship with glibc as the default which means that `stdc++` needs to be used instead of `c++` (which is used for LLVM).